### PR TITLE
Add manual typing for aws-sdk

### DIFF
--- a/manual-typings/aws-sdk/aws-sdk.d.ts
+++ b/manual-typings/aws-sdk/aws-sdk.d.ts
@@ -1,0 +1,5 @@
+declare module 'aws-sdk' {
+    export class Kinesis {
+        putRecord(record: any, cb: any): any;
+    }
+}


### PR DESCRIPTION
This should have been added in #4.
