### PR TITLE
Accept events with no trigger

### DIFF
--- a/src/emailingest.js
+++ b/src/emailingest.js
@@ -14,7 +14,6 @@ function validate(event) {
     if (!event.email)                    return reject("No email address");
     if (!event.listId)                   return reject("No listId");
     if (!event.emailGroup)               return reject("No emailGroup");
-    if (!event.triggeredSendKey)         return reject("No triggeredSendKey");
     if (!Validator.isEmail(event.email)) return reject("Invalid email address");
 
     resolve(event);
@@ -27,6 +26,9 @@ function makePutRequest(event) {
         listId: event.listId,
         emailGroup: event.emailGroup,
         triggeredSendKey: event.triggeredSendKey};
+
+    if (event.triggeredSendKey) {
+        data.triggeredSendKey = event.triggeredSendKey;}
 
     if (event.referrer) {
         data.referrer = event.referrer;}

--- a/src/triggersubscriberhandler.ts
+++ b/src/triggersubscriberhandler.ts
@@ -14,7 +14,7 @@ interface EmailData {
     email: string,
     listId: string,
     emailGroup: string,
-    triggeredSendKey: string,
+    triggeredSendKey?: string,
     referrer?: string,
     campaignCode?: string
 }
@@ -158,7 +158,11 @@ export const handleKinesisEvent = (kinesisEvent: KinesisEvent, context: any): Pr
         return Promise.resolve(kinesisEvent)
             .then(extractDataFromKinesisEvent)
             .then((emailDataList: Array<EmailData>) => {
-                const triggers: Promise<Array<any>> = Promise.map(emailDataList, createTriggeredSend).map(sendTriggeredSend);
+
+                const emailDataListWithTriggers: Array<EmailData> =
+                    emailDataList.filter((emailData) => emailData.triggeredSendKey !== undefined);
+
+                const triggers: Promise<Array<any>> = Promise.map(emailDataListWithTriggers, createTriggeredSend).map(sendTriggeredSend);
                 const subscriptions: Promise<Array<any>> = Promise.map(emailDataList, createSubscription).map(subscribeEmailToList);
 
                 return Promise.join(triggers, subscriptions)


### PR DESCRIPTION
This changes `emailingest` and `triggersubscibehandler` to accept events with no `triggeredSendKey`.

https://github.com/guardian/frontend/pull/11413 depends on this to be in place.

This allows signing up using a `listId` by itself.

@desbo @oliverjash
