### PR TITLE
Change updating of Subscriber Attributes

### DIFF
--- a/src/triggersubscriberhandler.ts
+++ b/src/triggersubscriberhandler.ts
@@ -35,30 +35,11 @@ const createOption: CreateOption = {
 
 const createTriggeredSend = (emailData: EmailData): TriggeredSend => {
     const email = emailData.email || '';
-    const emailGroup = emailData.emailGroup || '';
-    const referrer = emailData.referrer || '';
-    const campaignCode = emailData.campaignCode || '';
     const triggeredSendKey = emailData.triggeredSendKey || '';
-
-    const subscriberEmailGroup: ExtraAttribute = {
-        Name: 'Email group',
-        Value: emailGroup
-    };
-
-    const referrerAttribute: ExtraAttribute = {
-        Name: 'Referrer',
-        Value: referrer
-    };
-
-    const campaignCodeAttribute: ExtraAttribute = {
-        Name: 'CampaignCode',
-        Value: campaignCode
-    };
 
     const subscriber: Subscriber = {
         EmailAddress: email,
-        SubscriberKey: email,
-        Attributes: [ subscriberEmailGroup, referrerAttribute, campaignCodeAttribute ]
+        SubscriberKey: email
     };
 
     const triggeredSend = {
@@ -77,15 +58,37 @@ const createSubscription = (emailData: EmailData): Subscriber => {
     const email = emailData.email || '';
     const listId = emailData.listId || '';
 
+    const emailGroup = emailData.emailGroup;
+    const referrer = emailData.referrer;
+    const campaignCode = emailData.campaignCode;
+
     const listSubscriber: ListSubscriber = {
         ID: listId,
         Status: 'Active'
     };
 
+    const attributes: Array<ExtraAttribute> = [];
+
+    if (emailGroup) {
+        attributes.push({
+            Name: 'Email group',
+            Value: emailGroup});}
+
+    if (referrer) {
+        attributes.push({
+            Name: 'Referrer',
+            Value: referrer});}
+
+    if (campaignCode) {
+        attributes.push({
+            Name: 'CampaignCode',
+            Value: campaignCode});}
+
     const subscription = {
         EmailAddress: email,
         SubscriberKey: email,
-        Lists: [ listSubscriber ]
+        Lists: [ listSubscriber ],
+        Attributes: attributes
     };
 
     console.log("Created Subscription: " + JSON.stringify(subscription));


### PR DESCRIPTION
## Currently

Currently, if something exists inside these fields, they will stay the same from the beginning.
## Problem

Since https://github.com/guardian/frontend/pull/11413 and #10, we no longer get our custom attributes for `listId`s that don't have a `triggeredSendKey`.

Before, we did this when creating a `TriggeredSend`, but since we have removed the restriction of needing a triggered send ID for each list ID we allow a user to subscribe to, we won't get the attributes on subscriptions to lists without a triggered send ID.
## What

This changes the location (in code) of where we update custom `attributes` on a `Subscriber`.

This means after this PR, we will get the attributes back for lists without a triggered send ID.

There is one massive caveat though; the way it's done here means we ALWAYS update the `referrer` and `campaignCode` regardless of what is in there already.
## Decision

So we need to decide after :christmas_tree: , is the overriding OK? Or should we only update the fields if they don't exist/are populated?

@crifmulholland @desbo 
