### PR TITLE
bump node version to 6.1

### DIFF
--- a/cloudformation/emailsignup.yml
+++ b/cloudformation/emailsignup.yml
@@ -34,7 +34,7 @@ Resources:
       Description: >
         Initial handler of incoming emails; this just puts onto a Kinesis stream
       Handler: emailingest.handler
-      Runtime: nodejs
+      Runtime: nodejs6.10
       Role:
         Ref: LambdaRole
       Code:
@@ -49,7 +49,7 @@ Resources:
         Ingestion stream handler, this puts into ExactTarget and puts success
         failure onto a different stream.
       Handler: triggersubscriberhandler.handleKinesisEvent
-      Runtime: nodejs
+      Runtime: nodejs6.10
       Role:
         Ref: LambdaRole
       Timeout: 15


### PR DESCRIPTION
- Email Lambdas running on AWS were running on node 0.10, this is being deprecated by amazon so needs updating.
- This bumps the version in the cloud formation up to 6.1.
- This is live on PROD and has been tested in code and prod.

 