### PR TITLE
Activate subscriber on list subscription

### DIFF
--- a/manual-typings/fuel-soap/fuel-soap.d.ts
+++ b/manual-typings/fuel-soap/fuel-soap.d.ts
@@ -15,6 +15,7 @@ interface Subscriber {
     SubscriberKey: string;
     Lists?: Array<ListSubscriber>;
     Attributes?: Array<ExtraAttribute>;
+    Status: string;
 }
 
 interface TriggeredSendDefinition {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "vinyl-s3": "^0.3.0"
   },
   "dependencies": {
-    "fuel-soap": "^1.2.0",
+    "fuel-soap": "^1.6.0",
     "grunt-aws-lambda": "0.10.0",
     "monapt": "^0.5.0",
     "validator": "4.2.0"

--- a/src/triggersubscriberhandler.ts
+++ b/src/triggersubscriberhandler.ts
@@ -58,7 +58,8 @@ const createTriggeredSend = (emailData: EmailData): TriggeredSend => {
     const subscriber: Subscriber = {
         EmailAddress: email,
         SubscriberKey: email,
-        Attributes: [ subscriberEmailGroup, referrerAttribute, campaignCodeAttribute ]
+        Attributes: [ subscriberEmailGroup, referrerAttribute, campaignCodeAttribute ],
+        Status: "Active"
     };
 
     const triggeredSend = {
@@ -85,7 +86,8 @@ const createSubscription = (emailData: EmailData): Subscriber => {
     const subscription = {
         EmailAddress: email,
         SubscriberKey: email,
-        Lists: [ listSubscriber ]
+        Lists: [ listSubscriber ],
+        Status: "Active"
     };
 
     console.log("Created Subscription: " + JSON.stringify(subscription));


### PR DESCRIPTION
[Trello card](https://trello.com/c/7wiA1itk/407-email-signup-does-not-work-for-re-subscribers)

Activate subscriber on Editorial business unit level when subscribing to a list. This fixes the issue when subscribers unsubscribe from all, and then at some point in the future wish to re-subscribe.