### PR TITLE
Fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### AWS Credentials
 
-Ensure you have valid AWS credentials setup in `~/.aws/credentials`
+Ensure you have valid AWS credentials setup in `~/.aws/credentials` (for the frontend account)
 
 
 ### NPM, Gulp and Typescript

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@ var gulp   = require('gulp');
 var lambda = require('gulp-awslambda');
 var zip    = require('gulp-zip');
 var yaml = require('gulp-yaml');
-var s3 = require('vinyl-s3');
+var vinylS3 = require('vinyl-s3');
 var fail   = require('gulp-fail');
 var flatten = require('gulp-flatten');
 var runSequence = require('run-sequence');
@@ -72,7 +72,7 @@ gulp.task('buildEmailIngestHandler', ['writeConfig'], function() {
 gulp.task('uploadEmailIngestHandler', function() {
     var emailIngestHandler = 'email-ingest-handler-' + env +'.zip';
     return fs.src('dist/email-ingest/' + emailIngestHandler)
-        .pipe(s3.dest({
+        .pipe(vinylS3.dest({
             Bucket: 'aws-frontend-artifacts',
             Key: 'lambda'
         }));
@@ -105,7 +105,7 @@ gulp.task('buildSubscribeHandler', ['writeConfig'], function() {
 gulp.task('uploadSubscribeHandler', function() {
     var subscribeHandler = 'subscribe-handler-' + env +'.zip';
     return fs.src('dist/exact-target-handler/' + subscribeHandler)
-        .pipe(s3.dest({
+        .pipe(vinylS3.dest({
             Bucket: 'aws-frontend-artifacts',
             Key: 'lambda'
         }));
@@ -136,7 +136,7 @@ gulp.task('buildCloudformation', function() {
 
 //Credentials
 gulp.task('downloadCredentials', function() {
-    return s3.src('s3://aws-frontend-artifacts/lambda/email-signup-config-*.js',
+    return vinylS3.src('s3://aws-frontend-artifacts/lambda/email-signup-config-*.js',
      { buffer: false, s3: frontendS3 })
         .pipe(flatten())
         .pipe(gulp.dest('./node_modules'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,13 @@ var riffraff = require('./riffraff');
 
 var region = 'eu-west-1';
 
+var AWS = require('aws-sdk');
+AWS.config = new AWS.Config();
+AWS.config.region = "eu-west-1";
+var frontendS3 = new AWS.S3({
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID_FRONTEND,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY_FRONTEND});
+
 var lambdaOptions = {
     region: region
 };
@@ -129,7 +136,8 @@ gulp.task('buildCloudformation', function() {
 
 //Credentials
 gulp.task('downloadCredentials', function() {
-    return s3.src('s3://aws-frontend-artifacts/lambda/email-signup-config-*.js', { buffer: false })
+    return s3.src('s3://aws-frontend-artifacts/lambda/email-signup-config-*.js',
+     { buffer: false, s3: frontendS3 })
         .pipe(flatten())
         .pipe(gulp.dest('./node_modules'));
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "aws-sdk": "2.2.11",
+    "aws-sdk": "2.213.1",
     "bluebird": "^3.1.4",
     "grunt": "0.4.*",
     "grunt-aws-lambda": "0.10.0",
@@ -25,7 +25,7 @@
     "kinesis": "^1.2.2",
     "npm": "~3.3.9",
     "vinyl-fs": "^2.2.1",
-    "vinyl-s3": "^0.3.0"
+    "vinyl-s3": "^0.3.1"
   },
   "dependencies": {
     "fuel-soap": "^1.6.0",


### PR DESCRIPTION
Dotcom has encrypted its S3 buckets, so a recent version of the S3 sdk is now required to access them. This change bumps the aws-sdk version to fix this.

We're killing off teamcity.gu-web (this is the last app to move). The shared teamcity is in the deploy tools account and so it's awkward to give the agent instances access to files in the dotcom account. This change gets the build script to look for credentials in environment variables in order to access files in the dotcom s3 buckets.